### PR TITLE
Strip \uFFFF from danmaku

### DIFF
--- a/NSDanmaku/Helper/DanmakuParse.cs
+++ b/NSDanmaku/Helper/DanmakuParse.cs
@@ -49,7 +49,7 @@ namespace NSDanmaku.Helper
           
             XmlDocument xdoc = new XmlDocument();
             //处理下特殊字符
-            xmlStr = Regex.Replace(xmlStr, @"[\x00-\x08]|[\x0B-\x0C]|[\x0E-\x1F]", "");
+            xmlStr = Regex.Replace(xmlStr, @"[\x00-\x08]|[\x0B-\x0C]|[\x0E-\x1F]|[\uFFFF]", "");
             xdoc.LoadXml(xmlStr);
             XmlElement el = xdoc.DocumentElement;
             XmlNodeList xml = el.ChildNodes;

--- a/NSDanmaku/NSDanmaku.nuspec
+++ b/NSDanmaku/NSDanmaku.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>NSDanmaku</id>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <title>NSDanmaku</title>
     <authors>xiaoyaocz</authors>
     <owners>xiaoyaocz</owners>

--- a/NSDanmaku/Properties/AssemblyInfo.cs
+++ b/NSDanmaku/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.1.0")]
-[assembly: AssemblyFileVersion("1.5.1.0")]
+[assembly: AssemblyVersion("1.5.2.0")]
+[assembly: AssemblyFileVersion("1.5.2.0")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
It's unclear if \uFFFF has special meanings, just simply strip it.

Failure example:
<d p=\"41.07800,1,25,16777215,1570277203,0,c0c96cfb,22615177841606660\">感觉好\uffffA啊</d>

修复实况主的逃脱游戏第三话播放失败