### PR TITLE
Add ARM64 platform for NSDanmaku

### DIFF
--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -143,6 +143,32 @@
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <OutputPath>bin\ARM64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NSDanmaku.sln
+++ b/NSDanmaku.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2002
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31129.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSDanmaku", "NSDanmaku\NSDanmaku.csproj", "{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}"
 EndProject
@@ -11,10 +11,12 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
+		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
 		Release|ARM = Release|ARM
+		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
@@ -23,6 +25,8 @@ Global
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Debug|ARM.ActiveCfg = Debug|ARM
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Debug|ARM.Build.0 = Debug|ARM
+		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Debug|ARM64.Build.0 = Debug|ARM64
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Debug|x64.ActiveCfg = Debug|x64
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Debug|x64.Build.0 = Debug|x64
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Debug|x86.ActiveCfg = Debug|x86
@@ -31,6 +35,8 @@ Global
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Release|ARM.ActiveCfg = Release|ARM
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Release|ARM.Build.0 = Release|ARM
+		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Release|ARM64.ActiveCfg = Release|ARM64
+		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Release|ARM64.Build.0 = Release|ARM64
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Release|x64.ActiveCfg = Release|x64
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Release|x64.Build.0 = Release|x64
 		{964D5BCC-C063-45CC-AEEA-89169E4A2E5E}.Release|x86.ActiveCfg = Release|x86
@@ -39,6 +45,9 @@ Global
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|ARM.ActiveCfg = Debug|ARM
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|ARM.Build.0 = Debug|ARM
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|ARM.Deploy.0 = Debug|ARM
+		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|ARM64.Build.0 = Debug|ARM64
+		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|ARM64.Deploy.0 = Debug|ARM64
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|x64.ActiveCfg = Debug|x64
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|x64.Build.0 = Debug|x64
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Debug|x64.Deploy.0 = Debug|x64
@@ -49,6 +58,9 @@ Global
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|ARM.ActiveCfg = Release|ARM
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|ARM.Build.0 = Release|ARM
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|ARM.Deploy.0 = Release|ARM
+		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|ARM64.ActiveCfg = Release|ARM64
+		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|ARM64.Build.0 = Release|ARM64
+		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|ARM64.Deploy.0 = Release|ARM64
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|x64.ActiveCfg = Release|x64
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|x64.Build.0 = Release|x64
 		{30C4C949-95E5-4B7E-AD6E-099207050273}.Release|x64.Deploy.0 = Release|x64

--- a/NSDanmaku/NSDanmaku.csproj
+++ b/NSDanmaku/NSDanmaku.csproj
@@ -37,6 +37,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -156,6 +157,30 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <OutputPath>bin\ARM64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/NSDanmaku/NSDanmaku.nuspec
+++ b/NSDanmaku/NSDanmaku.nuspec
@@ -18,6 +18,8 @@
     </dependencies>
   </metadata>
   <files>
+	<file src="bin\ARM64\Release\NSDanmaku.dll" target="runtimes\win10-arm64\lib\uap10.0" />
+	<file src="bin\ARM64\Release\NSDanmaku.pdb" target="runtimes\win10-arm64\lib\uap10.0" />
     <file src="bin\ARM\Release\NSDanmaku.dll" target="runtimes\win10-arm\lib\uap10.0" />
     <file src="bin\ARM\Release\NSDanmaku.pdb" target="runtimes\win10-arm\lib\uap10.0" />
     <file src="bin\x64\Release\NSDanmaku.dll" target="runtimes\win10-x64\lib\uap10.0" />
@@ -27,7 +29,7 @@
     <file src="Controls\Danmaku.xaml" target="lib\uap10.0\Controls"/>
     <file src="Controls\TantanDialog.xaml" target="lib\uap10.0\Controls"/>
     <file src="Controls\TantanDialog.xaml" target="lib\uap10.0\Controls"/>
-    <file src="bin\Release\NSDanmaku.xr.xml" target="ref\uap10.0\NSDanmaku"/>
+    <file src="bin\Release\NSDanmaku\NSDanmaku.xr.xml" target="ref\uap10.0\NSDanmaku"/>
     <file src="bin\Release\NSDanmaku.dll" target="ref\uap10.0" />
     <file src="bin\Release\NSDanmaku.pri" target="ref\uap10.0" />
   </files>


### PR DESCRIPTION
**Changes:**
1. Use the Visual Studio 2019 version as default since it has fully support of ARM64 deployment.
2. Add ARM64 platform to both Demo.csproj and NSDanmaku.csproj
3. Add output dll to the nuspec.

**更改：**
1. 将 VS 2019 版本用作默认版本，因为它完全支持 ARM64 部署。
2. 将 ARM64 平台添加到 Demo.csproj 和 NSDanmaku.csproj
3. 将输出 dll 添加到 nuspec 中。
